### PR TITLE
add rules to strengthen security of user insert

### DIFF
--- a/.changeset/great-falcons-pay.md
+++ b/.changeset/great-falcons-pay.md
@@ -1,0 +1,7 @@
+---
+"@aeriajs/builtins": patch
+"@aeriajs/server": patch
+"@aeriajs/types": patch
+---
+
+add rules to strengthen security of user insert

--- a/packages/builtins/src/collections/user/description.ts
+++ b/packages/builtins/src/collections/user/description.ts
@@ -76,9 +76,6 @@ export const description = defineDescription({
         }
       },
     },
-    group: {
-      type: 'string',
-    },
     self_registered: {
       type: 'boolean',
       readOnly: true,

--- a/packages/builtins/src/collections/user/insert.ts
+++ b/packages/builtins/src/collections/user/insert.ts
@@ -10,56 +10,74 @@ export const insert = async <
   context: Context<TDescription>,
 ) => {
   const mutableProperties = context.config.security.mutableUserProperties
-  if(!context.token.authenticated){ 
-    return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthenticationError})
+  if(!context.token.authenticated){
+    return context.error(HTTPStatus.Unauthorized, {
+      code: ACError.AuthenticationError,
+    })
   }
   if(!mutableProperties){
-    return context.error(HTTPStatus.InternalServerError, {code:ACError.InsecureOperator})
+    return context.error(HTTPStatus.InternalServerError, {
+      code: ACError.InsecureOperator,
+    })
   }
   if( 'password' in payload.what && typeof payload.what.password === 'string' ) {
     payload.what.password = await bcrypt.hash(payload.what.password, 10)
   }
   if(('email' in payload.what)){
     if(!(typeof payload.what.email === 'string')){
-      return context.error(HTTPStatus.UnprocessableContent, {code:ACError.MalformedInput})
+      return context.error(HTTPStatus.UnprocessableContent, {
+        code: ACError.MalformedInput,
+      })
     }
     const existing = await context.collections.user.model.findOne({
-      email: payload.what.email
+      email: payload.what.email,
     })
     if(existing && existing.email !== context.token.userinfo.email){
-      const {error: noUser, result:user} = await context.collections.user.functions.get({
-        filters:{
-          _id: context.token.sub
-        }
+      const { error: noUser, result: user } = await context.collections.user.functions.get({
+        filters: {
+          _id: context.token.sub,
+        },
       })
       if(noUser){
-        return context.error(HTTPStatus.Forbidden, {code:ACError.ResourceNotFound})
+        return context.error(HTTPStatus.Forbidden, {
+          code: ACError.ResourceNotFound,
+        })
       }
       if(existing.email !== user.email && !context.token.roles.includes('root')){
-        return context.error(HTTPStatus.Forbidden, {code:ACError.MalformedInput})
+        return context.error(HTTPStatus.Forbidden, {
+          code: ACError.MalformedInput,
+        })
       }
     }
   }
 
   if(!context.token.roles.includes('root')){
-    const whatPropKeyArray = Object.keys(payload.what).filter(prop => prop !== "_id")
+    const whatPropKeyArray = Object.keys(payload.what).filter((prop) => prop !== '_id')
     if(whatPropKeyArray.some((prop:any) => !(mutableProperties.includes(prop)))){
-      return context.error(HTTPStatus.BadRequest, {code:ACError.MalformedInput})
+      return context.error(HTTPStatus.BadRequest, {
+        code: ACError.MalformedInput,
+      })
     }
     if('_id' in payload.what){
-      if(!context.token.sub){ 
-        return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthenticationError})
+      if(!context.token.sub){
+        return context.error(HTTPStatus.Unauthorized, {
+          code: ACError.AuthenticationError,
+        })
       }
       if(payload.what._id !== context.token.sub.toString()){
-        return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthorizationError})
+        return context.error(HTTPStatus.Unauthorized, {
+          code: ACError.AuthorizationError,
+        })
       }
       if('roles' in payload.what){
         payload.what.roles = context.token.roles
       }
-      
+
       return originalInsert(payload, context)
     }
-    return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthorizationError})
+    return context.error(HTTPStatus.Unauthorized, {
+      code: ACError.AuthorizationError,
+    })
   }
   return originalInsert(payload, context)
 }

--- a/packages/builtins/src/collections/user/insert.ts
+++ b/packages/builtins/src/collections/user/insert.ts
@@ -1,4 +1,4 @@
-import type { Context, SchemaWithId, InsertPayload, Description } from '@aeriajs/types'
+import { type Context, type SchemaWithId, type InsertPayload, type Description, HTTPStatus, ACError } from '@aeriajs/types'
 import { insert as originalInsert } from '@aeriajs/core'
 import * as bcrypt from 'bcrypt'
 
@@ -9,10 +9,48 @@ export const insert = async <
   payload: NoInfer<TInsertPayload>,
   context: Context<TDescription>,
 ) => {
+  if(!context.token.sub){ 
+    return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthenticationError})
+  }
   if( 'password' in payload.what && typeof payload.what.password === 'string' ) {
     payload.what.password = await bcrypt.hash(payload.what.password, 10)
   }
-
+  if(('email' in payload.what)){
+    if(!(typeof payload.what.email === 'string')){
+      return context.error(HTTPStatus.UnprocessableContent, {code:ACError.MalformedInput})
+    }
+    const existing = await context.collections.user.model.findOne({
+      email: payload.what.email
+    })
+    if(existing && existing.email !== context.token.userinfo.email){
+      const {error: noUser, result:user} = await context.collections.user.functions.get({
+        filters:{
+          _id: context.token.sub
+        }
+      })
+      if(noUser){
+        return context.error(HTTPStatus.Forbidden, {code:ACError.ResourceNotFound})
+      }
+      if(existing.email !== user.email){
+        return context.error(HTTPStatus.Forbidden, {code:ACError.OwnershipError})
+      }
+    }
+  }
+  if(!context.token.roles.includes('root')){
+    if('_id' in payload.what){
+      if(payload.what._id !== context.token.sub.toString()){
+        console.log('different ID')
+        return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthorizationError})
+      }
+      if('roles' in payload.what){
+        payload.what.roles = context.token.roles
+      }
+      
+      return originalInsert(payload, context)
+    }
+    console.log('not root')
+    return context.error(HTTPStatus.Unauthorized, {code:ACError.AuthorizationError})
+  }
   return originalInsert(payload, context)
 }
 

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -8,14 +8,13 @@ export const DEFAULT_API_CONFIG = {
     tokenExpiration: 36000,
     linkTokenExpiration: 36000,
     paginationLimit: 100,
-    mutableUserProperties:[
-      "email",
-      "name",
-      "password",
-      "phone_number",
-      "picture_file",
-    ]
+    mutableUserProperties: [
+      'email',
+      'name',
+      'password',
+      'phone_number',
+      'picture_file',
+    ],
   },
-
 
 } satisfies ApiConfig

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -8,6 +8,14 @@ export const DEFAULT_API_CONFIG = {
     tokenExpiration: 36000,
     linkTokenExpiration: 36000,
     paginationLimit: 100,
+    mutableUserProperties:[
+      "email",
+      "name",
+      "password",
+      "phone_number",
+      "picture_file",
+    ]
   },
+
 
 } satisfies ApiConfig

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -32,6 +32,7 @@ export type ApiConfig = {
     logSuccessfulAuthentications?: boolean
     authenticationRateLimiting?: RateLimitingParams | null
     allowSignup?: boolean
+    mutableUserProperties?: (keyof CollectionItem<'user'>)[]
     signupDefaults?: {
       roles?: string[]
       active?: boolean


### PR DESCRIPTION
unauthenticated actors can no longer use the default user insert function.
For authenticated users, now there is a verification for existing emails, and restrictions regarding modifiable props by non-root users throught apiConfig->security->mutableUserProperties.